### PR TITLE
[api] add dotnet example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Codex Agent Guide
+
+## Scope
+Entire project
+
+## Lint/Test
+- Lint: `dotnet format`
+- Test: `dotnet test`
+
+## PR Instructions
+- PR title format: `[api] <summary>`
+- Include a summary section with rationale and before/after behavior
+
+## Notes
+All code changes must pass linting and tests.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Install .NET SDK (adjust version as required)
+wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+sudo apt-get update && \
+sudo apt-get install -y apt-transport-https && \
+sudo apt-get update && \
+sudo apt-get install -y dotnet-sdk-8.0
+
+# Optional: verify installation
+dotnet --version
+
+# Restore dependencies
+dotnet restore
+
+# Optional: Run a quick test pass
+dotnet test --no-build --verbosity minimal

--- a/src/Daffodil.sln
+++ b/src/Daffodil.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DaffodilApp", "DaffodilApp/DaffodilApp.csproj", "{B9A6D749-1B77-4EB7-9C0A-0FEFE4C16B15}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DaffodilApp.Tests", "DaffodilApp.Tests/DaffodilApp.Tests.csproj", "{7C708147-1B78-4BEF-9105-223D4D6E837A}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {B9A6D749-1B77-4EB7-9C0A-0FEFE4C16B15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B9A6D749-1B77-4EB7-9C0A-0FEFE4C16B15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B9A6D749-1B77-4EB7-9C0A-0FEFE4C16B15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B9A6D749-1B77-4EB7-9C0A-0FEFE4C16B15}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7C708147-1B78-4BEF-9105-223D4D6E837A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7C708147-1B78-4BEF-9105-223D4D6E837A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7C708147-1B78-4BEF-9105-223D4D6E837A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7C708147-1B78-4BEF-9105-223D4D6E837A}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/src/DaffodilApp.Tests/DaffodilApp.Tests.csproj
+++ b/src/DaffodilApp.Tests/DaffodilApp.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../DaffodilApp/DaffodilApp.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/DaffodilApp.Tests/Tests/SampleTests.cs
+++ b/src/DaffodilApp.Tests/Tests/SampleTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace DaffodilApp.Tests
+{
+    public class SampleTests
+    {
+        [Fact]
+        public void TestHello()
+        {
+            Assert.Equal(2, 1 + 1);
+        }
+    }
+}

--- a/src/DaffodilApp/DaffodilApp.csproj
+++ b/src/DaffodilApp/DaffodilApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/DaffodilApp/Program.cs
+++ b/src/DaffodilApp/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace DaffodilApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from DaffodilApp!");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Codex agent instructions for dotnet
- provide a setup script to install the .NET SDK
- create a simple console app and xUnit test project

## Testing
- `bash setup.sh` *(fails: Could not connect to proxy)*
- `dotnet format` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*