### PR TITLE
[api] add skeleton authorship domain

### DIFF
--- a/src/DaffodilApp/Authorship/Features.cs
+++ b/src/DaffodilApp/Authorship/Features.cs
@@ -1,0 +1,8 @@
+namespace DaffodilApp.Authorship;
+
+/// <summary>
+/// Root container for feature implementations.
+/// </summary>
+public class Features
+{
+}

--- a/src/DaffodilApp/Authorship/Interactions.cs
+++ b/src/DaffodilApp/Authorship/Interactions.cs
@@ -1,0 +1,8 @@
+namespace DaffodilApp.Authorship;
+
+/// <summary>
+/// Root container for interaction logic.
+/// </summary>
+public class Interactions
+{
+}

--- a/src/DaffodilApp/Authorship/Operations.cs
+++ b/src/DaffodilApp/Authorship/Operations.cs
@@ -1,0 +1,8 @@
+namespace DaffodilApp.Authorship;
+
+/// <summary>
+/// Root container for operations domain logic.
+/// </summary>
+public class Operations
+{
+}

--- a/src/DaffodilApp/Authorship/Presentations.cs
+++ b/src/DaffodilApp/Authorship/Presentations.cs
@@ -1,0 +1,8 @@
+namespace DaffodilApp.Authorship;
+
+/// <summary>
+/// Root container for presentation logic.
+/// </summary>
+public class Presentations
+{
+}

--- a/src/DaffodilApp/AuthorshipDomain.cs
+++ b/src/DaffodilApp/AuthorshipDomain.cs
@@ -1,0 +1,32 @@
+using DaffodilApp.Authorship;
+
+namespace DaffodilApp;
+
+/// <summary>
+/// Root factory for the Authorship domain.
+/// </summary>
+public class AuthorshipDomain
+{
+    /// <summary>Operations aggregate root.</summary>
+    public Operations Operations { get; }
+
+    /// <summary>Presentations aggregate root.</summary>
+    public Presentations Presentations { get; }
+
+    /// <summary>Features aggregate root.</summary>
+    public Features Features { get; }
+
+    /// <summary>Interactions aggregate root.</summary>
+    public Interactions Interactions { get; }
+
+    /// <summary>
+    /// Constructs an AuthorshipDomain and initializes its aggregates.
+    /// </summary>
+    public AuthorshipDomain()
+    {
+        Operations = new Operations();
+        Presentations = new Presentations();
+        Features = new Features();
+        Interactions = new Interactions();
+    }
+}


### PR DESCRIPTION
## Summary
- add `AuthorshipDomain` factory class
- stub out `Operations`, `Presentations`, `Features`, and `Interactions` aggregate containers

## Testing
- `dotnet format` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*