### PR TITLE
[api] Add SplashScreen presentation classes

### DIFF
--- a/src/DaffodilApp.Tests/Tests/SplashScreenTests.cs
+++ b/src/DaffodilApp.Tests/Tests/SplashScreenTests.cs
@@ -1,0 +1,16 @@
+using DaffodilApp.Presentation;
+using Xunit;
+
+namespace DaffodilApp.Tests
+{
+    public class SplashScreenTests
+    {
+        [Fact]
+        public void SplashScreen_HasProfilesComponent()
+        {
+            var screen = new SplashScreen();
+            Assert.NotNull(screen.Profiles);
+            Assert.NotNull(screen.Profiles.Items);
+        }
+    }
+}

--- a/src/DaffodilApp/Presentation/SplashScreen.cs
+++ b/src/DaffodilApp/Presentation/SplashScreen.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace DaffodilApp.Presentation
+{
+    /// <summary>
+    /// Represents everything bound to the splash screen.
+    /// </summary>
+    public class SplashScreen
+    {
+        /// <summary>
+        /// Profiles component displayed on the splash screen.
+        /// </summary>
+        public Profiles Profiles { get; } = new Profiles();
+    }
+
+    /// <summary>
+    /// Component that groups multiple profiles on the splash screen.
+    /// </summary>
+    public class Profiles
+    {
+        /// <summary>
+        /// Collection of individual profile components.
+        /// </summary>
+        public List<Profile> Items { get; } = new();
+    }
+
+    /// <summary>
+    /// Individual profile component.
+    /// </summary>
+    public class Profile
+    {
+        /// <summary>
+        /// Optional display name for the profile.
+        /// </summary>
+        public string? Name { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SplashScreen` class that holds a `Profiles` component with a list of `Profile` components
- test that `SplashScreen` exposes the profiles component

## Testing
- `dotnet format --no-restore` *(fails: `dotnet: command not found`)*
- `dotnet test` *(fails: `dotnet: command not found`)*