### PR TITLE
[api] Add Books screen with subcomponents

### DIFF
--- a/src/DaffodilApp.Tests/Tests/BooksScreenTests.cs
+++ b/src/DaffodilApp.Tests/Tests/BooksScreenTests.cs
@@ -1,0 +1,16 @@
+using DaffodilApp.Presentation;
+using Xunit;
+
+namespace DaffodilApp.Tests
+{
+    public class BooksScreenTests
+    {
+        [Fact]
+        public void BooksScreen_HasBooksComponent()
+        {
+            var screen = new BooksScreen();
+            Assert.NotNull(screen.Books);
+            Assert.NotNull(screen.Books.Items);
+        }
+    }
+}

--- a/src/DaffodilApp/Presentation/BooksScreen.cs
+++ b/src/DaffodilApp/Presentation/BooksScreen.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace DaffodilApp.Presentation
+{
+    /// <summary>
+    /// Represents everything bound to the books screen.
+    /// </summary>
+    public class BooksScreen
+    {
+        /// <summary>
+        /// Books component displayed on the books screen.
+        /// </summary>
+        public Books Books { get; } = new Books();
+    }
+
+    /// <summary>
+    /// Component that groups multiple books on the books screen.
+    /// </summary>
+    public class Books
+    {
+        /// <summary>
+        /// Collection of individual book components.
+        /// </summary>
+        public List<Book> Items { get; } = new();
+    }
+
+    /// <summary>
+    /// Individual book component.
+    /// </summary>
+    public class Book
+    {
+        /// <summary>
+        /// Optional title for the book.
+        /// </summary>
+        public string? Title { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- create `BooksScreen` with `Books` and `Book` components
- add `BooksScreenTests` to verify the new screen

## Testing
- `dotnet format --no-restore` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*